### PR TITLE
Config file value is numeric

### DIFF
--- a/Invoke-DGASoftwareUpdateMaintenance/Invoke-DGASoftwareUpdateMaintenance.ps1
+++ b/Invoke-DGASoftwareUpdateMaintenance/Invoke-DGASoftwareUpdateMaintenance.ps1
@@ -857,7 +857,7 @@ If ($ConfigFile){
                         Set-Variable -Name $Data[0] -Value ($Data[1] -as [string]) -Force -WhatIf:$False
                     } ElseIf ($Data[1] -match "^@.") {
                         Set-Variable -Name $Data[0] -Value (Invoke-Expression $Data[1]) -Force -WhatIf:$False
-                    } ElseIf ($Data[1] -match "\d") {
+                    } ElseIf ($Data[1] -match "^[0-9]*$") { #case where entire value is numeric
                         Set-Variable -Name $Data[0] -Value ($Data[1] -as [int]) -Force -WhatIf:$False
                     } Else {
                         Set-Variable -Name $Data[0] -Value ($Data[1] -as [string]) -Force -WhatIf:$False


### PR DESCRIPTION
The regex to test for "is numeric" is actually testing for the existence of any number.  In the case of LogFile=\\server01\share\path\file.ext, the \d evaluates to true.  Then the value -as [int] doesn't throw an error (by design?) but leave the variable LogFile as null/empty.